### PR TITLE
整数转字符串效率

### DIFF
--- a/src/main/java/org/nutz/ssdb4j/impl/SimpleClient.java
+++ b/src/main/java/org/nutz/ssdb4j/impl/SimpleClient.java
@@ -97,7 +97,7 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response setx(Object key, Object val, int ttl) {
-		return req(Cmd.setx,bytes(key), bytes(val), (""+ttl).getBytes());
+		return req(Cmd.setx,bytes(key), bytes(val), new Integer(ttl).toString().getBytes());
 	}
 
 	@Override
@@ -107,7 +107,7 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response incr(Object key, int val) {
-		return req(Cmd.incr,bytes(key), (""+val).getBytes());
+		return req(Cmd.incr,bytes(key), new Integer(val).toString().getBytes());
 	}
 
 	@Override
@@ -117,7 +117,7 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response keys(Object start, Object end, int limit) {
-		return req(Cmd.keys,bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.keys,bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -137,12 +137,12 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response scan(Object start, Object end, int limit) {
-		return req(Cmd.scan,bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.scan,bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response rscan(Object start, Object end, int limit) {
-		return req(Cmd.rscan,bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.rscan,bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -167,26 +167,26 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response hlist(Object key, Object hkey, int limit) {
-		return req(Cmd.hlist,bytes(key), bytes(hkey), (""+limit).getBytes());
+		return req(Cmd.hlist,bytes(key), bytes(hkey), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response hincr(Object key, Object hkey, int val) {
-		return req(Cmd.hincr,bytes(key), bytes(hkey), (""+val).getBytes());
+		return req(Cmd.hincr,bytes(key), bytes(hkey), new Integer(val).toString().getBytes());
 	}
 
 	@Override
 	public Response hscan(Object key, Object start, Object end, int limit) {
-		return req(Cmd.hscan,bytes(key), bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.hscan,bytes(key), bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response hrscan(Object key, Object start, Object end, int limit) {
-		return req(Cmd.hrscan,bytes(key), bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.hrscan,bytes(key), bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	public Response zset(Object key, Object zkey, int score) {
-		return req(Cmd.zset,bytes(key), bytes(zkey), (""+score).getBytes());
+		return req(Cmd.zset,bytes(key), bytes(zkey), new Integer(score).toString().getBytes());
 	}
 
 	@Override
@@ -201,7 +201,7 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response zincr(Object key, Object zkey, int val) {
-		return req(Cmd.zincr,bytes(key), bytes(zkey), (""+val).getBytes());
+		return req(Cmd.zincr,bytes(key), bytes(zkey), new Integer(val).toString().getBytes());
 	}
 
 	@Override
@@ -211,7 +211,7 @@ public class SimpleClient implements SSDB {
 	
 	@Override
 	public Response zlist(Object zkey_start, Object zkey_end, int limit) {
-		return req(Cmd.zlist, bytes(zkey_start), bytes(zkey_end), (""+limit).getBytes());
+		return req(Cmd.zlist, bytes(zkey_start), bytes(zkey_end), new Integer(limit).toString().getBytes());
 	}
 	
 	@Override
@@ -226,12 +226,14 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response zscan(Object key, Object zkey_start, int score_start, int score_end, int limit) {
-		return req(Cmd.zscan, bytes(key), bytes(zkey_start), bytes(score_start), bytes(score_end), (""+limit).getBytes());
+		return req(Cmd.zscan, bytes(key), bytes(zkey_start), new Integer(score_start).toString().getBytes(), 
+		        new Integer(score_end).toString().getBytes(), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response zrscan(Object key, Object zkey_start, int score_start, int score_end, int limit) {
-		return req(Cmd.zrscan, bytes(key), bytes(zkey_start), bytes(score_start), bytes(score_end), (""+limit).getBytes());
+		return req(Cmd.zrscan, bytes(key), bytes(zkey_start), new Integer(score_start).toString().getBytes(), 
+                new Integer(score_end).toString().getBytes(), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -261,7 +263,7 @@ public class SimpleClient implements SSDB {
 	
 	@Override
 	public Response qlist(Object key_start, Object key_end, int limit) {
-		return req(Cmd.qlist, bytes(key_start), bytes(key_end), (""+limit).getBytes());
+		return req(Cmd.qlist, bytes(key_start), bytes(key_end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -271,7 +273,7 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response hkeys(Object key, Object start, Object end, int limit) {
-		return req(Cmd.hkeys, bytes(key), bytes(start), bytes(end), (""+limit).getBytes());
+		return req(Cmd.hkeys, bytes(key), bytes(start), bytes(end), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -311,17 +313,18 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response zkeys(Object key, Object zkey_start, int score_start, int score_end, int limit) {
-		return req(Cmd.zkeys, bytes(key), bytes(zkey_start), bytes(score_start), bytes(score_end), (""+limit).getBytes());
+		return req(Cmd.zkeys, bytes(key), bytes(zkey_start), new Integer(score_start).toString().getBytes(), 
+                new Integer(score_end).toString().getBytes(), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response zrange(Object key, int offset, int limit) {
-		return req(Cmd.zrange, bytes(key), (""+offset).getBytes(), (""+limit).getBytes());
+		return req(Cmd.zrange, bytes(key), new Integer(offset).toString().getBytes(), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
 	public Response zrrange(Object key, int offset, int limit) {
-		return req(Cmd.zrrange, bytes(key), (""+offset).getBytes(), (""+limit).getBytes());
+		return req(Cmd.zrrange, bytes(key), new Integer(offset).toString().getBytes(), new Integer(limit).toString().getBytes());
 	}
 
 	@Override
@@ -438,27 +441,27 @@ public class SimpleClient implements SSDB {
 
 	@Override
 	public Response qslice(Object key, int start, int end) {
-		return req(Cmd.qslice, bytes(key), (""+start).getBytes(), (""+end).getBytes());
+		return req(Cmd.qslice, bytes(key), new Integer(start).toString().getBytes(), new Integer(end).toString().getBytes());
 	}
 
 	@Override
 	public Response qget(Object key, int index) {
-		return req(Cmd.qget, bytes(key), (""+index).getBytes());
+		return req(Cmd.qget, bytes(key), new Integer(index).toString().getBytes());
 	}
 
 	@Override
 	public Response zcount(Object key, int start, int end) {
-		return req(Cmd.zcount, bytes(key), (""+start).getBytes(), (""+end).getBytes());
+		return req(Cmd.zcount, bytes(key), new Integer(start).toString().getBytes(), new Integer(end).toString().getBytes());
 	}
 
 	@Override
 	public Response zsum(Object key, int start, int end) {
-		return req(Cmd.zsum, bytes(key), (""+start).getBytes(), (""+end).getBytes());
+		return req(Cmd.zsum, bytes(key), new Integer(start).toString().getBytes(), new Integer(end).toString().getBytes());
 	}
 
 	@Override
 	public Response zavg(Object key, int start, int end) {
-		return req(Cmd.zavg, bytes(key), (""+start).getBytes(), (""+end).getBytes());
+		return req(Cmd.zavg, bytes(key), new Integer(start).toString().getBytes(), new Integer(end).toString().getBytes());
 	}
 	
 	@Override

--- a/src/main/java/org/nutz/ssdb4j/impl/SocketSSDBStream.java
+++ b/src/main/java/org/nutz/ssdb4j/impl/SocketSSDBStream.java
@@ -22,7 +22,8 @@ public class SocketSSDBStream extends AbstractIoSSDBStream {
 		this.port = port;
 		this.timeout = timeout;
 	}
-
+	
+	@Override
 	protected void beforeExec() {
 		if (!socket.isConnected()) {
 			try {

--- a/src/main/java/org/nutz/ssdb4j/pool/SocketSSDBStreamFactory.java
+++ b/src/main/java/org/nutz/ssdb4j/pool/SocketSSDBStreamFactory.java
@@ -16,11 +16,11 @@ public class SocketSSDBStreamFactory extends BasePoolableObjectFactory<SSDBStrea
 		this.port = port;
 		this.timeout = timeout;
 	}
-	
+	@Override
 	public SSDBStream makeObject() throws Exception {
 		return new SocketSSDBStream(host, port, timeout);
 	}
-
+	@Override
 	public boolean validateObject(SSDBStream stream) {
 		try {
 			return stream.req(Cmd.ping).ok();


### PR DESCRIPTION
整数num转成字符串，方式一：new
Integer(num).toString();方式二：num+"";方式一比方式二效率高40%以上（在PC上测试）。例子如下：

```
public static void main(String[] agrs) throws Exception{
long a = numToStr(true);
long b = numToStr(false);
System.out.println(new DecimalFormat("##.00%").format((b - a)*1.0f/b));
}
private static long numToStr(boolean flag){
String s = null;
Random rand = new Random();
int tem = 0;
long d = System.currentTimeMillis();
for(int i = 0; i < 1000000; i++){
tem = rand.nextInt(100000);
if(flag){
s = new Integer(tem).toString();
}else{
s = tem+"";
}
}
d = System.currentTimeMillis() - d;
if(flag){
System.out.println("toString方式 " + d);
}else{
System.out.println("连接方式 "+ d);
}
return d;
}
```
